### PR TITLE
add node-role.kubernetes.io/master toleration

### DIFF
--- a/Documentation/yurt-edgex-manager.yaml
+++ b/Documentation/yurt-edgex-manager.yaml
@@ -4595,3 +4595,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: edgex-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,10 @@ spec:
     spec:
       nodeSelector:
         openyurt.io/is-edge-worker: "false"
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
otherwise yurt-edgex-manager could not be deployed on master nodes.
