### PR TITLE
Unified controller and hub versions to ensure successful local debugging

### DIFF
--- a/api/v1alpha1/edgex_conversion.go
+++ b/api/v1alpha1/edgex_conversion.go
@@ -13,4 +13,57 @@ limitations under the License.
 
 package v1alpha1
 
-func (*EdgeX) Hub() {}
+import (
+	"github.com/openyurtio/yurt-edgex-manager/api/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+func (src *EdgeX) ConvertTo(dstRaw conversion.Hub) error {
+	// Transform metadata
+	dst := dstRaw.(*v1alpha2.EdgeX)
+	dst.ObjectMeta = src.ObjectMeta
+	dst.TypeMeta = src.TypeMeta
+	dst.TypeMeta.APIVersion = "device.openyurt.io/v1alpha2"
+
+	// Transform spec
+	dst.Spec.Version = src.Spec.Version
+	dst.Spec.Security = false
+	dst.Spec.ImageRegistry = src.Spec.ImageRegistry
+	dst.Spec.PoolName = src.Spec.PoolName
+
+	// Transform status
+	dst.Status.Ready = src.Status.Ready
+	dst.Status.Initialized = src.Status.Initialized
+	dst.Status.ReadyComponentNum = src.Status.DeploymentReadyReplicas
+	dst.Status.UnreadyComponentNum = src.Status.DeploymentReplicas - src.Status.DeploymentReadyReplicas
+	dst.Status.Conditions = src.Status.Conditions
+
+	//TODO: Components
+	return nil
+}
+func (dst *EdgeX) ConvertFrom(srcRaw conversion.Hub) error {
+	// Transform metadata
+	src := srcRaw.(*v1alpha2.EdgeX)
+	dst.ObjectMeta = src.ObjectMeta
+	dst.TypeMeta = src.TypeMeta
+	dst.TypeMeta.APIVersion = "device.openyurt.io/v1alpha1"
+
+	// Transform spec
+	dst.Spec.Version = src.Spec.Version
+	dst.Spec.ImageRegistry = src.Spec.ImageRegistry
+	dst.Spec.PoolName = src.Spec.PoolName
+	dst.Spec.ServiceType = corev1.ServiceTypeClusterIP
+
+	// Transform status
+	dst.Status.Ready = src.Status.Ready
+	dst.Status.Initialized = src.Status.Initialized
+	dst.Status.ServiceReadyReplicas = src.Status.ReadyComponentNum
+	dst.Status.ServiceReplicas = src.Status.ReadyComponentNum + src.Status.UnreadyComponentNum
+	dst.Status.DeploymentReadyReplicas = src.Status.ReadyComponentNum
+	dst.Status.DeploymentReplicas = src.Status.ReadyComponentNum + src.Status.UnreadyComponentNum
+	dst.Status.Conditions = src.Status.Conditions
+
+	//TODO: AdditionalService and AdditionalDeployment
+	return nil
+}

--- a/api/v1alpha1/edgex_types.go
+++ b/api/v1alpha1/edgex_types.go
@@ -88,7 +88,6 @@ type EdgeXStatus struct {
 //+kubebuilder:printcolumn:name="ReadyService",type="integer",JSONPath=".status.serviceReadyReplicas",description="The Ready Service Replica."
 //+kubebuilder:printcolumn:name="Deployment",type="integer",JSONPath=".status.deploymentReplicas",description="The Deployment Replica."
 //+kubebuilder:printcolumn:name="ReadyDeployment",type="integer",JSONPath=".status.deploymentReadyReplicas",description="The Ready Deployment Replica."
-//+kubebuilder:storageversion
 
 // EdgeX is the Schema for the edgexes API
 type EdgeX struct {

--- a/api/v1alpha2/edgex_conversion.go
+++ b/api/v1alpha2/edgex_conversion.go
@@ -16,48 +16,4 @@ limitations under the License.
 
 package v1alpha2
 
-import (
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/conversion"
-
-	"github.com/openyurtio/yurt-edgex-manager/api/v1alpha1"
-)
-
-func (src *EdgeX) ConvertTo(dstRaw conversion.Hub) error {
-	dst := dstRaw.(*v1alpha1.EdgeX)
-	dst.ObjectMeta = src.ObjectMeta
-	dst.TypeMeta = src.TypeMeta
-	dst.TypeMeta.APIVersion = "device.openyurt.io/v1alpha1"
-	dst.Spec.Version = src.Spec.Version
-	dst.Spec.ImageRegistry = src.Spec.ImageRegistry
-	dst.Spec.PoolName = src.Spec.PoolName
-	dst.Spec.ServiceType = corev1.ServiceTypeClusterIP
-	//TODO: AdditionalService and AdditionalDeployment
-
-	dst.Status.Ready = src.Status.Ready
-	dst.Status.Initialized = src.Status.Initialized
-	dst.Status.ServiceReadyReplicas = src.Status.ReadyComponentNum
-	dst.Status.ServiceReplicas = src.Status.ReadyComponentNum + src.Status.UnreadyComponentNum
-	dst.Status.DeploymentReadyReplicas = src.Status.ReadyComponentNum
-	dst.Status.DeploymentReplicas = src.Status.ReadyComponentNum + src.Status.UnreadyComponentNum
-	dst.Status.Conditions = src.Status.Conditions
-
-	return nil
-}
-func (dst *EdgeX) ConvertFrom(srcRaw conversion.Hub) error {
-	src := srcRaw.(*v1alpha1.EdgeX)
-	dst.ObjectMeta = src.ObjectMeta
-	dst.TypeMeta = src.TypeMeta
-	dst.TypeMeta.APIVersion = "device.openyurt.io/v1alpha2"
-	dst.Spec.Version = src.Spec.Version
-	dst.Spec.Security = false
-	dst.Spec.ImageRegistry = src.Spec.ImageRegistry
-	dst.Spec.PoolName = src.Spec.PoolName
-	//TODO: Components
-	dst.Status.Ready = src.Status.Ready
-	dst.Status.Initialized = src.Status.Initialized
-	dst.Status.ReadyComponentNum = src.Status.DeploymentReadyReplicas
-	dst.Status.UnreadyComponentNum = src.Status.DeploymentReplicas - src.Status.DeploymentReadyReplicas
-	dst.Status.Conditions = src.Status.Conditions
-	return nil
-}
+func (*EdgeX) Hub() {}

--- a/api/v1alpha2/edgex_types.go
+++ b/api/v1alpha2/edgex_types.go
@@ -79,6 +79,7 @@ type EdgeXStatus struct {
 //+kubebuilder:printcolumn:name="READY",type="boolean",JSONPath=".status.ready",description="The edgex ready status"
 //+kubebuilder:printcolumn:name="ReadyComponentNum",type="integer",JSONPath=".status.readyComponentNum",description="The Ready Component."
 //+kubebuilder:printcolumn:name="UnreadyComponentNum",type="integer",JSONPath=".status.unreadyComponentNum",description="The Unready Component."
+//+kubebuilder:storageversion
 
 // EdgeX is the Schema for the edgexes API
 type EdgeX struct {

--- a/config/crd/bases/device.openyurt.io_edgexes.yaml
+++ b/config/crd/bases/device.openyurt.io_edgexes.yaml
@@ -3384,7 +3384,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -3469,7 +3469,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
 status:

--- a/config/samples/beijing.yaml
+++ b/config/samples/beijing.yaml
@@ -1,4 +1,4 @@
-apiVersion: device.openyurt.io/v1alpha1
+apiVersion: device.openyurt.io/v1alpha2
 kind: EdgeX
 metadata:
   name: edgex-sample-beijing


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind enhancement
/sig iot

#### What this PR does / why we need it:
I unified the version of the controller and the version of conversion hub. Now they are both v1alpha2 and keep the webhook closed while `make run` local debugging, so now we can debug v1alpha2 functionality directly locally at development.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #79



